### PR TITLE
Extension/post browse times

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -62,6 +62,7 @@ function handleBrowsing(tabId) {
 
     // TODO: make POST request
     testGetRequest();
+    testPostRequest();
   });
 }
 
@@ -84,6 +85,16 @@ function testGetRequest() {
   };
 
   request.send();
+}
+
+function testPostRequest() {
+  const request = new XMLHttpRequest();
+  request.open("POST", "http://localhost:9000/api/user/login", true);
+  request.setRequestHeader(
+    "Content-Type",
+    "application/json"
+  );
+  request.send(JSON.stringify({ email: "a@a.com", password: "password" }));
 }
 function getDomainFromUrl(url) {
   const urlObj = new URL(url);

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -99,6 +99,19 @@ function postBrowseTime(hostName, durationInSeconds) {
   request.send(JSON.stringify({ hostName, durationInSeconds }));
 }
 
+/**
+ * Logs into the server
+ */
+function login() {
+  const request = new XMLHttpRequest();
+  request.open("POST", "http://localhost:9000/api/user/login", true);
+  request.setRequestHeader(
+    "Content-Type",
+    "application/json"
+  );
+  request.send(JSON.stringify({ email: "a@a.com", password: "password" }));
+}
+
 function getDomainFromUrl(url) {
   const urlObj = new URL(url);
   const domain = urlObj.hostname.split("www.").join("");

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -56,13 +56,11 @@ function handleBrowsing(tabId) {
     // tab.url will be undefined on chrome settings page etc.
     const currentDomain = tab.url ? getDomainFromUrl(tab.url) : undefined;
     console.log(`domain was at ${lastDomain} for ${timerInSeconds} seconds`);
+    postBrowseTime(lastDomain, timerInSeconds);
     console.log("domain is now", currentDomain);
     lastDomain = currentDomain;
     timerInSeconds = 0;
-
-    // TODO: make POST request
     testGetRequest();
-    testPostRequest();
   });
 }
 
@@ -87,15 +85,20 @@ function testGetRequest() {
   request.send();
 }
 
-function testPostRequest() {
+/**
+ * Sends post request to server to add the browse session to browse_times table
+ */
+function postBrowseTime(hostName, durationInSeconds) {
   const request = new XMLHttpRequest();
-  request.open("POST", "http://localhost:9000/api/user/login", true);
-  request.setRequestHeader(
-    "Content-Type",
-    "application/json"
+  request.open(
+    "POST",
+    "http://localhost:9000/api/extension/add_browse_time",
+    true
   );
-  request.send(JSON.stringify({ email: "a@a.com", password: "password" }));
+  request.setRequestHeader("Content-Type", "application/json");
+  request.send(JSON.stringify({ hostName, durationInSeconds }));
 }
+
 function getDomainFromUrl(url) {
   const urlObj = new URL(url);
   const domain = urlObj.hostname.split("www.").join("");

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -30,6 +30,8 @@ setInterval(() => {
   console.log(timerInSeconds);
 }, 1000);
 
+let lastDomain;
+
 // Triggers when page loads in current tab
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   if (changeInfo.status === "complete" && tab.active) {
@@ -50,9 +52,11 @@ chrome.tabs.onActivated.addListener(function (activeInfo) {
  */
 function handleBrowsing(tabId) {
   chrome.tabs.get(tabId, (tab) => {
+    console.log("domain was at", lastDomain);
     console.log("timer was at", timerInSeconds);
     console.log("tab is now", tabId);
     console.log("domain is now", tab.url);
+    lastDomain = tab.url;
     timerInSeconds = 0;
   });
 }

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -61,9 +61,30 @@ function handleBrowsing(tabId) {
     timerInSeconds = 0;
 
     // TODO: make POST request
+    testGetRequest();
   });
 }
 
+function testGetRequest() {
+  const request = new XMLHttpRequest();
+  request.open("GET", "http://localhost:9000", true);
+
+  request.onload = function () {
+    if (this.status >= 200 && this.status < 400) {
+      // Success!
+      const data = JSON.parse(this.response);
+      console.log(data);
+    } else {
+      // We reached our target server, but it returned an error
+    }
+  };
+
+  request.onerror = function () {
+    // There was a connection error of some sort
+  };
+
+  request.send();
+}
 function getDomainFromUrl(url) {
   const urlObj = new URL(url);
   const domain = urlObj.hostname.split("www.").join("");

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -26,8 +26,7 @@ chrome.runtime.onInstalled.addListener(function () {
 let timerInSeconds = 0;
 
 setInterval(() => {
-  timerInSeconds++;
-  console.log(timerInSeconds);
+  timerInSeconds++;  
 }, 1000);
 
 let lastDomain;
@@ -55,9 +54,8 @@ function handleBrowsing(tabId) {
   chrome.tabs.get(tabId, (tab) => {
     // tab.url will be undefined on chrome settings page etc.
     const currentDomain = tab.url ? getDomainFromUrl(tab.url) : undefined;
-    console.log(`domain was at ${lastDomain} for ${timerInSeconds} seconds`);
-    postBrowseTime(lastDomain, timerInSeconds);
-    console.log("domain is now", currentDomain);
+    // console.log(`domain was at ${lastDomain} for ${timerInSeconds} seconds`);
+    postBrowseTime(lastDomain, timerInSeconds);    
     lastDomain = currentDomain;
     timerInSeconds = 0;
     //login(); // uncomment if you want to login

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -46,31 +46,27 @@ chrome.tabs.onActivated.addListener(function (activeInfo) {
 });
 
 /**
- * Function that is to be called when user navigates to a new site. Resets
- * the timer and gets the url.
+ * Function that is to be called when user clicks a new tab or visits a new
+ * page in the current tab. Gets the url and current timer to make POST
+ * request to add browsing time to db. Resets the timer.
  * @param {Number} tabId
  */
 function handleBrowsing(tabId) {
   chrome.tabs.get(tabId, (tab) => {
-    console.log("domain was at", lastDomain);
-    console.log("timer was at", timerInSeconds);
-    console.log("tab is now", tabId);
-    console.log("domain is now", tab.url);
-    lastDomain = tab.url;
+    // tab.url will be undefined on chrome settings page etc.
+    const currentDomain = tab.url ? getDomainFromUrl(tab.url) : undefined;
+    console.log(`domain was at ${lastDomain} for ${timerInSeconds} seconds`);
+    console.log("domain is now", currentDomain);
+    lastDomain = currentDomain;
     timerInSeconds = 0;
+
+    // TODO: make POST request
   });
 }
 
-function getDomainFromCurrentTab() {
-  let domain;
-  chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
-    // Will be null on chrome settings page etc
-    if (!tabs[0] || !tabs[0].url) {
-      domain = "other";
-    }
-    const url = new URL(tabs[0].url);
-    domain = url.hostname.split("www.").join("");
-  });
+function getDomainFromUrl(url) {
+  const urlObj = new URL(url);
+  const domain = urlObj.hostname.split("www.").join("");
   return domain;
 }
 

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -33,21 +33,26 @@ setInterval(() => {
 // Triggers when page loads in current tab
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   if (changeInfo.status === "complete" && tab.active) {
-    handleTimerWithTabId(tabId);
+    handleBrowsing(tabId);
     changePictures(tabId);
   }
 });
 
 // Triggers when user goes to a different tab
 chrome.tabs.onActivated.addListener(function (activeInfo) {
-  handleTimerWithTabId(activeInfo.tabId);
+  handleBrowsing(activeInfo.tabId);
 });
 
-function handleTimerWithTabId(tabId) {
+/**
+ * Function that is to be called when user navigates to a new site. Resets
+ * the timer and gets the url.
+ * @param {Number} tabId
+ */
+function handleBrowsing(tabId) {
   chrome.tabs.get(tabId, (tab) => {
     console.log("timer was at", timerInSeconds);
-    console.log("tab id was", tabId);
-    console.log("domain was", tab.url);
+    console.log("tab is now", tabId);
+    console.log("domain is now", tab.url);
     timerInSeconds = 0;
   });
 }

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -34,15 +34,18 @@ setInterval(() => {
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   if (changeInfo.status === "complete" && tab.active) {
     console.log("timer was at", timerInSeconds);
+    console.log("tab id was", tabId);
     timerInSeconds = 0;
     changePictures(tabId);
   }
 });
 
 // Triggers when user goes to a different tab
-// chrome.tabs.onActivated.addListener(function (activeInfo) {
-//   changePictures(activeInfo.tabId);
-// });
+chrome.tabs.onActivated.addListener(function (activeInfo) {
+  console.log("timer was at", timerInSeconds);
+  console.log("tab id was", activeInfo.tabId);
+  timerInSeconds = 0;  
+});
 
 /**
  * Checks if current tab's url is on the blacklist then injects content

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -23,9 +23,18 @@ chrome.runtime.onInstalled.addListener(function () {
   });
 });
 
+let timerInSeconds = 0;
+
+setInterval(() => {
+  timerInSeconds++;
+  console.log(timerInSeconds);
+}, 1000);
+
 // Triggers when page loads in current tab
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   if (changeInfo.status === "complete" && tab.active) {
+    console.log("timer was at", timerInSeconds);
+    timerInSeconds = 0;
     changePictures(tabId);
   }
 });

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -60,7 +60,7 @@ function handleBrowsing(tabId) {
     console.log("domain is now", currentDomain);
     lastDomain = currentDomain;
     timerInSeconds = 0;
-    testGetRequest();
+    //login(); // uncomment if you want to login
   });
 }
 
@@ -77,11 +77,9 @@ function testGetRequest() {
       // We reached our target server, but it returned an error
     }
   };
-
   request.onerror = function () {
     // There was a connection error of some sort
   };
-
   request.send();
 }
 
@@ -95,6 +93,15 @@ function postBrowseTime(hostName, durationInSeconds) {
     "http://localhost:9000/api/extension/add_browse_time",
     true
   );
+  request.onload = function () {
+    const data = JSON.parse(this.response);
+    
+    if (this.status >= 200 && this.status < 400) {
+      console.log(data);
+    } else {
+      console.log(data);
+    }
+  };
   request.setRequestHeader("Content-Type", "application/json");
   request.send(JSON.stringify({ hostName, durationInSeconds }));
 }
@@ -105,10 +112,7 @@ function postBrowseTime(hostName, durationInSeconds) {
 function login() {
   const request = new XMLHttpRequest();
   request.open("POST", "http://localhost:9000/api/user/login", true);
-  request.setRequestHeader(
-    "Content-Type",
-    "application/json"
-  );
+  request.setRequestHeader("Content-Type", "application/json");
   request.send(JSON.stringify({ email: "a@a.com", password: "password" }));
 }
 

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -33,19 +33,37 @@ setInterval(() => {
 // Triggers when page loads in current tab
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   if (changeInfo.status === "complete" && tab.active) {
-    console.log("timer was at", timerInSeconds);
-    console.log("tab id was", tabId);
-    timerInSeconds = 0;
+    handleTimerWithTabId(tabId);
     changePictures(tabId);
   }
 });
 
 // Triggers when user goes to a different tab
 chrome.tabs.onActivated.addListener(function (activeInfo) {
-  console.log("timer was at", timerInSeconds);
-  console.log("tab id was", activeInfo.tabId);
-  timerInSeconds = 0;  
+  handleTimerWithTabId(activeInfo.tabId);
 });
+
+function handleTimerWithTabId(tabId) {
+  chrome.tabs.get(tabId, (tab) => {
+    console.log("timer was at", timerInSeconds);
+    console.log("tab id was", tabId);
+    console.log("domain was", tab.url);
+    timerInSeconds = 0;
+  });
+}
+
+function getDomainFromCurrentTab() {
+  let domain;
+  chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
+    // Will be null on chrome settings page etc
+    if (!tabs[0] || !tabs[0].url) {
+      domain = "other";
+    }
+    const url = new URL(tabs[0].url);
+    domain = url.hostname.split("www.").join("");
+  });
+  return domain;
+}
 
 /**
  * Checks if current tab's url is on the blacklist then injects content

--- a/server/db/schema/04_browse_times.sql
+++ b/server/db/schema/04_browse_times.sql
@@ -7,6 +7,22 @@ CREATE TABLE browse_times
   user_id             INTEGER       REFERENCES users(id) ON DELETE CASCADE,
   website_id          INTEGER       REFERENCES websites(id) ON DELETE CASCADE,
 
-  datetime_start      TIMESTAMP     WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  datetime_start      TIMESTAMP     WITH TIME ZONE,
   duration            INTERVAL      NOT NULL DEFAULT '1 minute'
-)
+);
+
+-- Calculate datetime_start from current_timestamp and duration
+create or replace function insert_browse_time() returns trigger as $$
+begin
+	if NEW.datetime_start is null then
+		NEW.datetime_start := CURRENT_TIMESTAMP - NEW.duration;
+	end if;
+	return new;
+end;
+$$ language plpgsql;
+
+create trigger trig_insert_browse_times
+before insert
+on browse_times
+for each row
+execute procedure insert_browse_time();

--- a/server/db/seeds/02_websites.sql
+++ b/server/db/seeds/02_websites.sql
@@ -5,25 +5,11 @@ VALUES
 INSERT INTO websites
   (hostname, name, category)
 VALUES
-  ('reddit.com','Reddit', 'Internet Media');
-
-INSERT INTO websites
-  (hostname, name, category)
-VALUES
-  ('facebook.com', 'Facebook', 'Social Media');
-
-INSERT INTO websites
-  (hostname, name, category)
-VALUES
-  ('twitter.com', 'Twitter', 'Social Media');
-
-INSERT INTO websites
-  (hostname, name, category)
-VALUES
-  ('espn.com', 'ESPN', 'Sports');
-
-INSERT INTO websites
-  (hostname, name, category)
-VALUES
-  ('cnn.com', 'CNN', 'News');
-
+  ('reddit.com', 'Reddit', 'Internet Media'),
+  ('facebook.com', 'Facebook', 'Social Media'),
+  ('twitter.com', 'Twitter', 'Social Media'),
+  ('espn.com', 'ESPN', 'Sports'),
+  ('cnn.com', 'CNN', 'News'),
+  ('instagram.com', 'Instagram', 'Social Media'),
+  ('pinterest.ca', 'Pinterest', 'Social Media'),
+  ('youtube.com', 'Youtube', 'Video');

--- a/server/db/seeds/03_blacklist.sql
+++ b/server/db/seeds/03_blacklist.sql
@@ -1,45 +1,19 @@
 INSERT INTO blacklists
   (user_id, website_id)
 VALUES
-  (1, 1);
-
-INSERT INTO blacklists
-  (user_id, website_id)
-VALUES
-  (1, 3);
-
-INSERT INTO blacklists
-  (user_id, website_id)
-VALUES
-  (2, 4);
-
-INSERT INTO blacklists
-  (user_id, website_id)
-VALUES
-  (2, 2);
-
--- Adding Friends' Facebook to users blacklisted sites:
-INSERT INTO blacklists
-  (user_id, website_id)
-VALUES
-  (3, 2);
-  INSERT INTO blacklists
-  (user_id, website_id)
-VALUES
-  (4, 2);
-  INSERT INTO blacklists
-  (user_id, website_id)
-VALUES
-  (5, 2);
-  INSERT INTO blacklists
-  (user_id, website_id)
-VALUES
-  (6, 2);
-  INSERT INTO blacklists
-  (user_id, website_id)
-VALUES
-  (7, 2);
-  INSERT INTO blacklists
-  (user_id, website_id)
-VALUES
+  (1, 1),
+  (1, 2),
+  (1, 3),
+  (1, 5),
+  (1, 6),
+  (1, 7),
+  (1, 8),
+  (2, 4),
+  (2, 2),
+  -- Adding Friends' Facebook to users blacklisted sites:
+  (3, 2),
+  (4, 2),
+  (5, 2),
+  (6, 2),
+  (7, 2),
   (8, 2);

--- a/server/helpers/dbHelper.js
+++ b/server/helpers/dbHelper.js
@@ -180,7 +180,7 @@ module.exports = (db) => {
       .query(
         `
         INSERT INTO browse_times (user_id, website_id, duration)
-        VALUES ($1, $2, $4)
+        VALUES ($1, $2, $3)
         RETURNING *;
         `,
         [user_id, website_id, duration]

--- a/server/helpers/dbHelper.js
+++ b/server/helpers/dbHelper.js
@@ -18,7 +18,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const getUserWithID = function (id) {
@@ -34,7 +35,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const addUser = function (first_name, last_name, email, password) {
@@ -50,7 +52,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const getBlacklistedSitesWithUserID = function (id) {
@@ -67,7 +70,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows;
-      });
+      })
+      .catch((err) => err);
   };
 
   const getAllWebsites = function () {
@@ -80,7 +84,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows;
-      });
+      })
+      .catch((err) => err);
   };
 
   const addWebsite = function (hostname, name, category) {
@@ -96,7 +101,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const addWebsiteToBlacklist = function (user_id, website_id) {
@@ -112,7 +118,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const addQuotaForUser = function (
@@ -134,10 +141,13 @@ module.exports = (db) => {
       queryParams.push(date_valid_from, date_valid_until);
     }
 
-    return db.query(queryString, queryParams).then((res) => {
-      if (res.rows.length === 0) return null;
-      return res.rows[0];
-    });
+    return db
+      .query(queryString, queryParams)
+      .then((res) => {
+        if (res.rows.length === 0) return null;
+        return res.rows[0];
+      })
+      .catch((err) => err);
   };
 
   const getAllQuotasWithUserID = function (user_id) {
@@ -152,7 +162,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows;
-      });
+      })
+      .catch((err) => err);
   };
 
   const getBrowseInfoWithUserID = function (user_id) {
@@ -172,7 +183,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows;
-      });
+      })
+      .catch((err) => err);
   };
 
   const addBrowseTimesToUserID = function (user_id, website_id, duration) {
@@ -188,7 +200,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const getTotalTimeForTodayByUserID = function (user_id) {
@@ -207,7 +220,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const getTotalBlacklistTimeForTodayByUserID = function (user_id) {
@@ -227,7 +241,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const getQuotaForTodayWithUserID = function (user_id) {
@@ -244,7 +259,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const getWebsiteIDByHostname = function (hostname) {
@@ -259,7 +275,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows[0];
-      });
+      })
+      .catch((err) => err);
   };
 
   const getBrowseInfoTodayForDashboard = function (user_id) {
@@ -280,7 +297,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows;
-      });
+      })
+      .catch((err) => err);
   };
 
   const getMonthBlacklistBrowsingInfoForChart = function (user_id) {
@@ -300,7 +318,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows;
-      });
+      })
+      .catch((err) => err);
   };
 
   const getTimeForLeaderboardWeek = function () {
@@ -321,7 +340,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows;
-      });
+      })
+      .catch((err) => err);
   };
 
   const getTimeForShameboardWeek = function () {
@@ -342,7 +362,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows;
-      });
+      })
+      .catch((err) => err);
   };
 
   const getHitsForBlacklistedSiteForPastWeek = (user_id) => {
@@ -362,7 +383,8 @@ module.exports = (db) => {
       .then((res) => {
         if (res.rows.length === 0) return null;
         return res.rows;
-      });
+      })
+      .catch((err) => err);
   };
 
   return {

--- a/server/routes/extensionRoutes.js
+++ b/server/routes/extensionRoutes.js
@@ -1,0 +1,32 @@
+const express = require("express");
+const router = express.Router();
+
+module.exports = (db) => {
+  const dbHelper = require("../helpers/dbHelper")(db);
+  
+  router.post("/add_browse_time", (req, res) => {
+    const userId = req.session.userId;
+    if (!userId) {
+      return res.status(403).send("A user must be signed in!");
+    }
+
+    const { host_name, durationInSeconds } = req.body.params;
+
+    // Check if host_name given is in user's blacklist
+    dbHelper
+      .getBlacklistedSitesWithUserID(userId)
+      .then((blacklists) => {})
+      .catch((err) => res.status(500).json(err));
+
+    // using host_name, insert website_id, datetime_start, duration, etc into the db.
+    dbHelper
+      .getWebsiteIDByHostname(host_name)
+      .then((site) => {
+        dbHelper.addBrowseTimesToUserID(user_id, site.id, durationInSeconds);
+      })
+      .catch((err) => res.json(err));
+  });
+
+
+  return router;
+};

--- a/server/routes/extensionRoutes.js
+++ b/server/routes/extensionRoutes.js
@@ -7,11 +7,15 @@ module.exports = (db) => {
   router.post("/add_browse_time", (req, res) => {
     const userId = req.session.userId;
     if (!userId) {
-      return res.status(403).send("A user must be signed in!");
+      return res.status(403).json("A user must be signed in!");
     }
-        
+
     const { hostName, durationInSeconds } = req.body;
 
+    // Skip adding if duration was 0 seconds or no hostname provided
+    if (!hostName || durationInSeconds <= 0) {
+      return res.status(400).json("Invalid data");
+    }
     // Check if given hostName is in user's blacklist
     dbHelper
       .getBlacklistedSitesWithUserID(userId)
@@ -27,17 +31,19 @@ module.exports = (db) => {
                 `${durationInSeconds} seconds`
               );
             })
+            .then((data) => res.status(201).json(data))
             .catch((err) => res.status(500).json(err));
         } else {
           // If hostName is not in blacklist, use website_id of 0 (good site)
           dbHelper
             .addBrowseTimesToUserID(userId, 0, `${durationInSeconds} seconds`)
+            .then((data) => res.status(201).json(data))
             .catch((err) => {
               res.status(500).json(err);
             });
         }
       })
-      .catch((err) => {
+      .catch((err) => {        
         res.status(500).json(err);
       });
   });

--- a/server/routes/extensionRoutes.js
+++ b/server/routes/extensionRoutes.js
@@ -3,30 +3,44 @@ const router = express.Router();
 
 module.exports = (db) => {
   const dbHelper = require("../helpers/dbHelper")(db);
-  
+
   router.post("/add_browse_time", (req, res) => {
     const userId = req.session.userId;
     if (!userId) {
       return res.status(403).send("A user must be signed in!");
     }
+        
+    const { hostName, durationInSeconds } = req.body;
 
-    const { host_name, durationInSeconds } = req.body.params;
-
-    // Check if host_name given is in user's blacklist
+    // Check if given hostName is in user's blacklist
     dbHelper
       .getBlacklistedSitesWithUserID(userId)
-      .then((blacklists) => {})
-      .catch((err) => res.status(500).json(err));
-
-    // using host_name, insert website_id, datetime_start, duration, etc into the db.
-    dbHelper
-      .getWebsiteIDByHostname(host_name)
-      .then((site) => {
-        dbHelper.addBrowseTimesToUserID(user_id, site.id, durationInSeconds);
+      .then((blacklists) => {
+        const hostnameArray = blacklists.map((site) => site.hostname);
+        if (hostnameArray.includes(hostName)) {
+          dbHelper
+            .getWebsiteIDByHostname(hostName)
+            .then((site) => {
+              return dbHelper.addBrowseTimesToUserID(
+                userId,
+                site.id,
+                `${durationInSeconds} seconds`
+              );
+            })
+            .catch((err) => res.status(500).json(err));
+        } else {
+          // If hostName is not in blacklist, use website_id of 0 (good site)
+          dbHelper
+            .addBrowseTimesToUserID(userId, 0, `${durationInSeconds} seconds`)
+            .catch((err) => {
+              res.status(500).json(err);
+            });
+        }
       })
-      .catch((err) => res.json(err));
+      .catch((err) => {
+        res.status(500).json(err);
+      });
   });
-
 
   return router;
 };

--- a/server/server.js
+++ b/server/server.js
@@ -48,6 +48,7 @@ const rootRoutes = require("./routes/rootRoutes");
 const userRoutes = require("./routes/userRoutes");
 const apiRoutes = require("./routes/apiRoutes");
 const dataRoutes = require("./routes/dataRoutes");
+const extensionRoutes = require("./routes/extensionRoutes");
 
 // Mount all resource routes
 // Note: Feel free to replace the example routes below with your own
@@ -55,6 +56,7 @@ app.use("/", rootRoutes(db));
 app.use("/api", apiRoutes(db));
 app.use("/api/user", userRoutes(db));
 app.use("/api/data", dataRoutes(db));
+app.use("/api/extension", extensionRoutes(db));
 
 // to do routes:
 // login


### PR DESCRIPTION
Closes #36 
Closes #37
Extension now automatically sends browsing info to server everytime page loads or you switch tabs. You can see detailed console logs in the extension's background page (link to it is in extension settings). Make sure to login first (through React page or uncommenting line 63 in background.js).

Also added postgres script to automatically calculate start of browsing time by subtracting duration from current_timestamp.

Also added seeds (note the syntax for inserting multiple values @riztaha).

Also added `.catch` to all dbHelper queries so db error messages can be retrieved.