### PR TITLE
change links to point to github release

### DIFF
--- a/client/src/components/LogoText.jsx
+++ b/client/src/components/LogoText.jsx
@@ -35,6 +35,8 @@ const Logo = styled.img`
       target="_blank"
     > */
 
+const EXTENSION_URL = "https://github.com/LHL-FocusPocus/FocusPocus/releases"
+// const EXTENSION_URL = "https://chrome.google.com/webstore/detail/focus-pocus-extension/ognhkeempdpgnfkliplegljejeakonlg/"
 
 export default function LogoText() {
 
@@ -45,7 +47,7 @@ const imageClick = () => {
   return (
     <Container>
     <ClickableLink 
-      href="https://chrome.google.com/webstore/detail/focus-pocus-extension/ognhkeempdpgnfkliplegljejeakonlg/"
+      href={EXTENSION_URL}
       target="_blank"
     > 
       <Logo src="/imgs/logo3.png" />

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -104,7 +104,8 @@ const Container = styled.div`
   height: 100%;
   width: 350px;
 `;
-
+const EXTENSION_URL = "https://github.com/LHL-FocusPocus/FocusPocus/releases"
+// const EXTENSION_URL = "https://chrome.google.com/webstore/detail/focus-pocus-extension/ognhkeempdpgnfkliplegljejeakonlg/"
 export default function Navbar({ user, quota, setDashboard }) {
   const classes = useStyles();
   const history = useHistory();
@@ -199,7 +200,7 @@ export default function Navbar({ user, quota, setDashboard }) {
           </ListItem>
         ))}
         <a
-          href="http://chrome.google.com/webstore/detail/focus-pocus-extension/ognhkeempdpgnfkliplegljejeakonlg/"
+          href={EXTENSION_URL}
           target="_blank"
           className={classes.anchor}
         >


### PR DESCRIPTION
Sorry guys the extension from the chrome web store somehow isn't working at 100%. Maybe Google does some modifications to the file somehow, not really sure.

I changed the link to point to the release page where users can install it manually by downloading a zip file. I tested this zip file and it seems to be working. The extension in this zip file does connect to online servers.